### PR TITLE
Add endpoints and UI for editing player pools

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -61,6 +61,12 @@
   </div>
 
   <pre id="outOptimize"></pre>
+  <div id="poolControls" style="display:none; margin:10px 0;">
+    <button id="btnLoadPool">Preview Player Pool</button>
+    <button id="btnSavePool" disabled>Save changes</button>
+    <span id="poolMeta" style="margin-left:10px;"></span>
+  </div>
+  <div id="poolTableWrap" style="max-height:400px; overflow:auto; border:1px solid #ccc; display:none;"></div>
 </fieldset>
 
 
@@ -109,6 +115,11 @@ document.addEventListener("DOMContentLoaded", () => {
   const mappingForm = document.getElementById("mappingForm");
   const mappingGrid = document.getElementById("mappingGrid");
   const outOptimize = document.getElementById("outOptimize");
+  const poolControls = document.getElementById("poolControls");
+  const poolMeta = document.getElementById("poolMeta");
+  const poolTableWrap = document.getElementById("poolTableWrap");
+  const btnLoadPool = document.getElementById("btnLoadPool");
+  const btnSavePool = document.getElementById("btnSavePool");
 
   const REQUIRED_KEYS = ["player_id","name","team","position","salary","projection"];
   const OPTIONAL_KEYS = [
@@ -116,6 +127,141 @@ document.addEventListener("DOMContentLoaded", () => {
     "min_deviation","max_deviation","projection_floor","projection_ceil",
     "confirmed_starter","progressive_scale"
   ];
+
+  let lastJobId = null;
+  let poolCache = [];
+  const poolDirty = new Map();
+
+  function resetPoolUI(){
+    poolDirty.clear();
+    btnSavePool.disabled = true;
+  }
+
+  function onOptimizeResponse(json){
+    outOptimize.textContent = JSON.stringify(json, null, 2);
+    lastJobId = json?.job?.job_id || null;
+    poolControls.style.display = lastJobId ? "block" : "none";
+    poolMeta.textContent = "";
+    poolTableWrap.style.display = "none";
+    poolTableWrap.innerHTML = "";
+    resetPoolUI();
+    poolCache = [];
+  }
+
+  function printOptimize(json){
+    onOptimizeResponse(json);
+  }
+
+  async function loadPool(){
+    if(!lastJobId){
+      alert("No job_id. Run Optimize first.");
+      return;
+    }
+    const r = await fetch(`${API}/jobs/${lastJobId}/pool`);
+    if(!r.ok){
+      alert(`Failed to load pool: ${r.status}`);
+      return;
+    }
+    const js = await r.json();
+    poolCache = js.players || [];
+    if(js.error){
+      alert(js.error);
+    }
+    const total = typeof js.count === "number" ? js.count : poolCache.length;
+    const shown = Math.min(poolCache.length, 200);
+    poolMeta.textContent = shown < total ? `rows: ${total} (showing ${shown})` : `rows: ${total}`;
+    resetPoolUI();
+    renderPoolTable(poolCache.slice(0, 200));
+  }
+
+  function renderPoolTable(rows){
+    const wrap = poolTableWrap;
+    wrap.style.display = "block";
+    if(!rows.length){
+      wrap.innerHTML = "<i>No rows.</i>";
+      return;
+    }
+
+    const escapeHtml = (value) => String(value ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    const escapeAttr = (value) => escapeHtml(value).replace(/"/g, "&quot;");
+
+    const cols = ["player_id","name","team","position","salary","projection","active","lock","exclude","max_exposure","min_exposure"];
+    const thead = `<thead><tr>${cols.map(c=>`<th style="position:sticky;top:0;background:#fafafa">${escapeHtml(c)}</th>`).join("")}</tr></thead>`;
+    const body = rows.map(row=>{
+      const pid = row.player_id;
+      const pidAttr = escapeAttr(pid);
+      const cell = (col)=>{
+        const rawVal = row[col] ?? "";
+        if(["projection","max_exposure","min_exposure"].includes(col)){
+          return `<td><input type="text" data-pid="${pidAttr}" data-key="${col}" value="${escapeAttr(rawVal)}" style="width:6em"/></td>`;
+        }
+        if(["active","lock","exclude"].includes(col)){
+          const checked = String(rawVal).toLowerCase() === "true" ? "checked" : "";
+          return `<td style="text-align:center"><input type="checkbox" data-pid="${pidAttr}" data-key="${col}" ${checked}/></td>`;
+        }
+        return `<td>${escapeHtml(rawVal)}</td>`;
+      };
+      return `<tr>${cols.map(cell).join("")}</tr>`;
+    }).join("");
+
+    wrap.innerHTML = `<table style="border-collapse:collapse;width:100%">${thead}<tbody>${body}</tbody></table>`;
+
+    wrap.querySelectorAll('input[type="text"]').forEach(inp=>{
+      inp.addEventListener("change", (event)=>{
+        const pid = event.target.dataset.pid;
+        const key = event.target.dataset.key;
+        const value = event.target.value;
+        const existing = poolDirty.get(pid) || { player_id: pid };
+        existing[key] = value;
+        poolDirty.set(pid, existing);
+        btnSavePool.disabled = false;
+      });
+    });
+
+    wrap.querySelectorAll('input[type="checkbox"]').forEach(box=>{
+      box.addEventListener("change", (event)=>{
+        const pid = event.target.dataset.pid;
+        const key = event.target.dataset.key;
+        const value = event.target.checked;
+        const existing = poolDirty.get(pid) || { player_id: pid };
+        existing[key] = value;
+        poolDirty.set(pid, existing);
+        btnSavePool.disabled = false;
+      });
+    });
+  }
+
+  btnLoadPool.onclick = loadPool;
+
+  btnSavePool.onclick = async ()=>{
+    if(!lastJobId){
+      return;
+    }
+    const updates = Array.from(poolDirty.values());
+    if(!updates.length){
+      return;
+    }
+    try{
+      const r = await fetch(`${API}/jobs/${lastJobId}/pool`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ players: updates })
+      });
+      if(!r.ok){
+        alert(`Save failed: ${r.status}`);
+        return;
+      }
+      const js = await r.json();
+      if(!js.ok){
+        alert(js.error || "Save failed");
+        return;
+      }
+      await loadPool();
+      alert(`Saved ${js.changed} rows.`);
+    }catch(err){
+      alert(err.message || "Save failed");
+    }
+  };
 
   function readSettings(){
     return {
@@ -212,7 +358,7 @@ document.addEventListener("DOMContentLoaded", () => {
     fd.append("mapping", JSON.stringify(mapping));
     const r = await fetch(`${API}/optimize`, { method:"POST", body:fd });
     const js = await r.json().catch(()=>({error:"non-JSON"}));
-    outOptimize.textContent = JSON.stringify(js, null, 2);
+    printOptimize(js);
   };
 
   // localStorage templates


### PR DESCRIPTION
## Summary
- add GET and POST endpoints to read and update each job's `pool_input.csv`
- extend the frontend to preview, edit, and save player pool rows from the optimize results

## Testing
- python -m compileall backend/app/main.py frontend/index.html

------
https://chatgpt.com/codex/tasks/task_b_68e56ed2396c8328a1f11861f9855f9c