### PR TITLE
Add minimal solve endpoint and UI wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,51 @@
 # DFS Optimizer (Dockerized scaffold)
 
-Backend: **FastAPI** + **pydfs-lineup-optimizer** with **CBC** via `python-mip`.  
+Backend: **FastAPI** + **pydfs-lineup-optimizer** with **CBC** via `python-mip`.
 Frontend: Static placeholder served by **nginx**.
 
 ## Run
 
 ```bash
 docker compose up --build
+```
+
+## Creating a "return to here" restore point
+
+When you reach a stable milestone and want a quick way to jump back to it, create
+either a lightweight tag or a dedicated branch in Git. Both approaches record the
+current commit so you can return to it later without disrupting ongoing work.
+
+### Option 1: lightweight tag
+
+```bash
+git tag snapshot-2024-xx-yy
+git push origin snapshot-2024-xx-yy
+```
+
+Tags are ideal for bookmarking a state. Replace `snapshot-2024-xx-yy` with any
+descriptive label. To return later, either check out the commit directly or
+create a temporary branch from the tag:
+
+```bash
+git checkout snapshot-2024-xx-yy    # detached HEAD at the tagged commit
+# or
+git checkout -b restore snapshot-2024-xx-yy
+```
+
+### Option 2: checkpoint branch
+
+```bash
+git checkout -b checkpoint/stable-ui
+git push -u origin checkpoint/stable-ui
+```
+
+Checkpoint branches behave like ordinary branches, so you can merge or cherry
+pick from them as needed. When you are ready to return to that snapshot:
+
+```bash
+git checkout checkpoint/stable-ui
+```
+
+You can remove the branch or tag later with `git branch -D` / `git push origin
+--delete` or `git tag -d` / `git push origin :refs/tags/<tag>` once it is no
+longer needed.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,11 @@ from pydantic import BaseModel, ValidationError
 from typing import Optional, Dict, Any, List, Tuple
 from uuid import uuid4
 from pathlib import Path
-import io, csv as csvmod, json, os
+import io, csv as csvmod, json, os, re
+
+from pydfs_lineup_optimizer import get_optimizer
+from pydfs_lineup_optimizer.player import Player
+from pydfs_lineup_optimizer.exceptions import LineupOptimizerException, GenerateLineupException
 
 DATA_DIR = Path("/app/data")  # added near the top of the file is fine
 
@@ -24,6 +28,14 @@ class OptimizeRequest(BaseModel):
     solver: str = "mip"
     pool_size: int = 150
     params: Dict[str, Any] = {}
+
+
+class SolveRequest(BaseModel):
+    job_id: str
+    num_lineups: int = 20
+    site: str = "FANDUEL"
+    sport: str = "NFL"
+    solver: str = "mip"
 
 @app.get("/health")
 def health():
@@ -199,3 +211,589 @@ async def optimize(
         "normalized": normalized,
         "job": job,  # NEW: paths + id (None if no mapping or no players)
     }
+
+
+def _csv_bool_to_str(v: Any) -> str:
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    s = str(v).strip().lower()
+    if s in ("1", "true", "t", "yes", "y"):
+        return "true"
+    if s in ("0", "false", "f", "no", "n"):
+        return "false"
+    return "false"
+
+
+def _csv_float_or_empty(v: Any) -> str:
+    if v is None:
+        return ""
+    try:
+        return str(float(v))
+    except Exception:
+        return ""
+
+
+def _projection_is_zero(value: Any) -> bool:
+    if value is None:
+        return False
+    s = str(value).strip()
+    if not s:
+        return False
+    try:
+        return float(s) == 0.0
+    except Exception:
+        return False
+
+
+def _parse_positions(value: Any) -> List[str]:
+    if value is None:
+        return []
+    text = str(value).replace("D/ST", "DST")
+    parts = re.split(r"[/,;]+", text)
+    positions = [p.strip().upper() for p in parts if p and p.strip()]
+    return positions
+
+
+def _split_name(full_name: str) -> Tuple[str, str]:
+    bits = full_name.split()
+    if not bits:
+        return "", ""
+    if len(bits) == 1:
+        return bits[0], ""
+    return bits[0], " ".join(bits[1:])
+
+
+def _parse_percentish(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("%"):
+        text = text[:-1]
+    try:
+        num = float(text)
+    except Exception:
+        return None
+    if num < 0:
+        num = 0.0
+    if num > 1.0:
+        if num <= 100.0:
+            num = num / 100.0
+        else:
+            num = 1.0
+    return num
+
+
+def _optional_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return _to_float(text)
+
+
+def _optional_bool(value: Any) -> Optional[bool]:
+    result = _to_bool(value)
+    return result
+
+
+def _read_pool_rows(job_id: str) -> Tuple[List[Dict[str, Any]], List[str]]:
+    job_dir = DATA_DIR / "jobs" / job_id
+    pool_csv = job_dir / "pool_input.csv"
+    if not pool_csv.exists():
+        raise FileNotFoundError("pool_input.csv not found")
+
+    with pool_csv.open("r", encoding="utf-8", newline="") as f:
+        reader = csvmod.DictReader(f)
+        rows = list(reader)
+        headers = reader.fieldnames or []
+    return rows, headers
+
+
+def _coerce_pool_player(row: Dict[str, Any], index: int) -> Tuple[Optional[Dict[str, Any]], List[str]]:
+    errors: List[str] = []
+    projection_val = row.get("projection")
+    projection = _to_float(projection_val)
+    salary = _to_int(row.get("salary"))
+
+    exclude_raw = row.get("exclude")
+    active_raw = row.get("active")
+    lock_raw = row.get("lock")
+
+    exclude = _optional_bool(exclude_raw)
+    if exclude is None:
+        exclude = _projection_is_zero(projection_val)
+
+    active = _optional_bool(active_raw)
+    if active is None:
+        active = not exclude
+
+    lock = bool(_optional_bool(lock_raw) or False)
+
+    if exclude:
+        active = False
+
+    if lock and exclude:
+        errors.append("player is both locked and excluded")
+
+    if lock and not active:
+        # lock should imply active participation
+        errors.append("locked player is marked inactive")
+
+    player_id = str(row.get("player_id") or "").strip()
+    if not player_id:
+        errors.append("missing player_id")
+
+    name = str(row.get("name") or "").strip()
+    if not name:
+        errors.append("missing name")
+
+    team = str(row.get("team") or "").strip()
+
+    positions = _parse_positions(row.get("position"))
+    if not positions:
+        errors.append("missing position")
+
+    if salary is None:
+        errors.append("invalid salary")
+
+    if projection is None:
+        errors.append("invalid projection")
+
+    max_exposure = _parse_percentish(row.get("max_exposure"))
+    min_exposure = _parse_percentish(row.get("min_exposure"))
+    if max_exposure is not None and min_exposure is not None and min_exposure > max_exposure:
+        errors.append("min_exposure greater than max_exposure")
+
+    projected_ownership = _parse_percentish(row.get("projected_ownership"))
+    min_deviation = _optional_float(row.get("min_deviation"))
+    max_deviation = _optional_float(row.get("max_deviation"))
+    projection_floor = _optional_float(row.get("projection_floor"))
+    projection_ceil = _optional_float(row.get("projection_ceil"))
+    progressive_scale = _optional_float(row.get("progressive_scale"))
+    confirmed_starter = _optional_bool(row.get("confirmed_starter"))
+
+    include = (active and not exclude) or lock
+
+    first_name, last_name = _split_name(name)
+
+    if errors:
+        return None, errors
+
+    player = {
+        "player_id": player_id,
+        "first_name": first_name or name,
+        "last_name": last_name,
+        "full_name": name,
+        "team": team,
+        "positions": positions,
+        "salary": salary,
+        "projection": projection,
+        "lock": lock,
+        "active": active,
+        "exclude": exclude,
+        "include": include,
+        "max_exposure": max_exposure,
+        "min_exposure": min_exposure,
+        "projected_ownership": projected_ownership,
+        "min_deviation": min_deviation,
+        "max_deviation": max_deviation,
+        "projection_floor": projection_floor,
+        "projection_ceil": projection_ceil,
+        "progressive_scale": progressive_scale,
+        "confirmed_starter": confirmed_starter,
+        "row_index": index,
+    }
+    return player, []
+
+
+def _prepare_players_for_solver(job_id: str) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[str], Dict[str, int]]:
+    rows, _ = _read_pool_rows(job_id)
+    players: List[Dict[str, Any]] = []
+    locked: List[Dict[str, Any]] = []
+    warnings: List[str] = []
+    stats = {
+        "total_rows": len(rows),
+        "eligible": 0,
+        "skipped_inactive": 0,
+    }
+
+    for idx, row in enumerate(rows, start=2):
+        player, errors = _coerce_pool_player(row, idx)
+        if errors:
+            lock_flag = bool(_optional_bool(row.get("lock")))
+            message = f"Row {idx}: {', '.join(errors)}"
+            if lock_flag:
+                raise ValueError(message)
+            warnings.append(message)
+            continue
+
+        if not player["include"]:
+            stats["skipped_inactive"] += 1
+            continue
+
+        players.append(player)
+        stats["eligible"] += 1
+        if player["lock"]:
+            locked.append(player)
+
+    return players, locked, warnings, stats
+
+
+@app.get("/jobs/{job_id}/pool")
+def get_pool(job_id: str):
+    job_dir = DATA_DIR / "jobs" / job_id
+    pool_csv = job_dir / "pool_input.csv"
+    if not pool_csv.exists():
+        return {"players": [], "count": 0, "error": "pool_input.csv not found"}
+
+    with pool_csv.open("r", encoding="utf-8", newline="") as f:
+        reader = csvmod.DictReader(f)
+        rows = list(reader)
+        headers = reader.fieldnames or []
+
+    default_cols = ["active", "lock", "exclude", "max_exposure", "min_exposure"]
+    for col in default_cols:
+        if col not in headers:
+            headers.append(col)
+
+    for row in rows:
+        projection_val = row.get("projection")
+        projection_is_zero = _projection_is_zero(projection_val)
+
+        exclude_val = row.get("exclude")
+        if exclude_val is None or str(exclude_val).strip() == "":
+            # Default: auto-exclude zero projection players
+            row["exclude"] = "true" if projection_is_zero else "false"
+        else:
+            row["exclude"] = _csv_bool_to_str(exclude_val)
+
+        active_val = row.get("active")
+        if active_val is None or str(active_val).strip() == "":
+            # Default active only when the player is not auto-excluded
+            row["active"] = "false" if row.get("exclude") == "true" else "true"
+        else:
+            row["active"] = _csv_bool_to_str(active_val)
+            if row.get("exclude") == "true":
+                # Prevent conflicting states when exclude is active
+                row["active"] = "false"
+
+        lock_val = row.get("lock")
+        if lock_val is None or str(lock_val).strip() == "":
+            row["lock"] = "false"
+        else:
+            row["lock"] = _csv_bool_to_str(lock_val)
+
+        for exposure_key in ("max_exposure", "min_exposure"):
+            exposure_val = row.get(exposure_key)
+            if exposure_val is None or str(exposure_val).strip() == "":
+                row[exposure_key] = ""
+            else:
+                row[exposure_key] = _csv_float_or_empty(exposure_val)
+
+    return {"players": rows, "count": len(rows)}
+
+
+@app.post("/jobs/{job_id}/pool")
+async def update_pool(job_id: str, body: Dict[str, Any]):
+    job_dir = DATA_DIR / "jobs" / job_id
+    pool_csv = job_dir / "pool_input.csv"
+    if not pool_csv.exists():
+        return {"ok": False, "error": "pool_input.csv not found"}
+
+    with pool_csv.open("r", encoding="utf-8", newline="") as f:
+        reader = csvmod.DictReader(f)
+        current_rows = list(reader)
+        headers = reader.fieldnames or []
+
+    default_cols = ["active", "lock", "exclude", "max_exposure", "min_exposure"]
+    for col in default_cols:
+        if col not in headers:
+            headers.append(col)
+            for row in current_rows:
+                projection_val = row.get("projection")
+                projection_is_zero = _projection_is_zero(projection_val)
+                if col == "active":
+                    row[col] = "false" if projection_is_zero else "true"
+                elif col == "exclude":
+                    row[col] = "true" if projection_is_zero else "false"
+                elif col == "lock":
+                    row[col] = "false"
+                else:
+                    row[col] = ""
+
+    index = {row.get("player_id"): i for i, row in enumerate(current_rows)}
+
+    updates = body.get("players") or []
+    changed = 0
+    for update in updates:
+        player_id = update.get("player_id")
+        if player_id is None or player_id not in index:
+            continue
+
+        row = current_rows[index[player_id]]
+        row_changed = False
+
+        for key, value in update.items():
+            if key == "player_id":
+                continue
+
+            if key not in headers:
+                headers.append(key)
+                for existing_row in current_rows:
+                    existing_row.setdefault(key, "")
+
+            if key == "salary":
+                try:
+                    row[key] = str(int(float(value)))
+                    row_changed = True
+                except Exception:
+                    continue
+            elif key == "projection":
+                try:
+                    row[key] = str(float(value))
+                    row_changed = True
+                except Exception:
+                    continue
+            elif key in ("active", "lock", "exclude"):
+                row[key] = _csv_bool_to_str(value)
+                row_changed = True
+            elif key in ("max_exposure", "min_exposure"):
+                row[key] = _csv_float_or_empty(value)
+                row_changed = True
+            else:
+                row[key] = "" if value is None else str(value)
+                row_changed = True
+
+        if row_changed:
+            changed += 1
+
+    for row in current_rows:
+        if row.get("exclude") == "true":
+            row["active"] = "false"
+
+    with pool_csv.open("w", encoding="utf-8", newline="") as f:
+        writer = csvmod.DictWriter(f, fieldnames=headers)
+        writer.writeheader()
+        for row in current_rows:
+            writer.writerow(row)
+
+    return {"ok": True, "changed": changed, "count": len(current_rows)}
+
+
+SPORT_ALIASES = {
+    "NFL": "FOOTBALL",
+    "NCAAF": "COLLEGE_FOOTBALL",
+    "CFL": "CANADIAN_FOOTBALL",
+    "NBA": "BASKETBALL",
+    "WNBA": "WNBA",
+    "MLB": "BASEBALL",
+    "NHL": "HOCKEY",
+    "LOL": "LEAGUE_OF_LEGENDS",
+}
+
+
+ALLOWED_SOLVERS = {"mip", "pulp"}
+
+
+def _resolve_sport(value: str) -> str:
+    key = (value or "").upper()
+    return SPORT_ALIASES.get(key, key)
+
+
+def _build_optimizer_player(data: Dict[str, Any]) -> Player:
+    return Player(
+        player_id=data["player_id"],
+        first_name=data["first_name"],
+        last_name=data["last_name"],
+        positions=data["positions"],
+        team=data["team"],
+        salary=float(data["salary"]),
+        fppg=float(data["projection"]),
+        max_exposure=data["max_exposure"],
+        min_exposure=data["min_exposure"],
+        projected_ownership=data["projected_ownership"],
+        min_deviation=data["min_deviation"],
+        max_deviation=data["max_deviation"],
+        is_confirmed_starter=data["confirmed_starter"],
+        fppg_floor=data["projection_floor"],
+        fppg_ceil=data["projection_ceil"],
+        progressive_scale=data["progressive_scale"],
+        original_positions=data["positions"],
+    )
+
+
+@app.post("/solve")
+async def solve(request: SolveRequest):
+    job_id = request.job_id
+    try:
+        players_data, locked_data, warnings, stats = _prepare_players_for_solver(job_id)
+    except FileNotFoundError:
+        return {"ok": False, "error": "pool_input.csv not found", "job_id": job_id}
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc), "job_id": job_id}
+
+    if not players_data:
+        return {
+            "ok": False,
+            "job_id": job_id,
+            "error": "No eligible players after applying active/exclude flags.",
+            "warnings": warnings,
+            "stats": stats,
+        }
+
+    solver_key = (request.solver or "mip").lower()
+    if solver_key not in ALLOWED_SOLVERS:
+        return {"ok": False, "job_id": job_id, "error": f"Unsupported solver '{request.solver}'"}
+
+    site_key = (request.site or "FANDUEL").upper()
+    sport_key = _resolve_sport(request.sport)
+
+    try:
+        optimizer = get_optimizer(site_key, sport_key, solver=solver_key)
+    except Exception as exc:
+        return {"ok": False, "job_id": job_id, "error": f"Failed to initialize optimizer: {exc}"}
+
+    optimizer_players: List[Player] = []
+    player_lookup: Dict[str, Player] = {}
+    for pdata in players_data:
+        player_obj = _build_optimizer_player(pdata)
+        optimizer_players.append(player_obj)
+        player_lookup[pdata["player_id"]] = player_obj
+
+    optimizer.load_players(optimizer_players)
+
+    locked_ids = {p["player_id"] for p in locked_data}
+    for pdata in locked_data:
+        player_obj = player_lookup.get(pdata["player_id"])
+        if player_obj:
+            optimizer.add_player_to_lineup(player_obj)
+
+    requested = max(1, min(int(request.num_lineups or 1), 150))
+
+    lineups: List[Dict[str, Any]] = []
+    job_dir = DATA_DIR / "jobs" / job_id
+    job_dir.mkdir(parents=True, exist_ok=True)
+    lineups_path = job_dir / "lineups.csv"
+
+    try:
+        for idx, lineup in enumerate(optimizer.optimize(requested), start=1):
+            lineup_players: List[Dict[str, Any]] = []
+            for lp in lineup.lineup:
+                lineup_players.append(
+                    {
+                        "player_id": lp.id,
+                        "name": lp.full_name,
+                        "team": lp.team,
+                        "positions": list(lp.positions),
+                        "lineup_position": lp.lineup_position,
+                        "salary": int(lp.salary),
+                        "projection": round(float(lp.fppg), 3),
+                        "used_projection": round(float(lp.used_fppg), 3) if lp.used_fppg is not None else None,
+                        "locked": lp.id in locked_ids,
+                    }
+                )
+
+            lineups.append(
+                {
+                    "index": idx,
+                    "salary": int(lineup.salary_costs),
+                    "projection": round(float(lineup.fantasy_points_projection), 3),
+                    "projection_actual": round(float(lineup.actual_fantasy_points_projection), 3),
+                    "players": lineup_players,
+                }
+            )
+    except GenerateLineupException as exc:
+        return {
+            "ok": False,
+            "job_id": job_id,
+            "error": str(exc),
+            "warnings": warnings,
+            "stats": stats,
+        }
+    except LineupOptimizerException as exc:
+        return {
+            "ok": False,
+            "job_id": job_id,
+            "error": str(exc),
+            "warnings": warnings,
+            "stats": stats,
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "job_id": job_id,
+            "error": f"Solver error: {exc}",
+            "warnings": warnings,
+            "stats": stats,
+        }
+
+    if not lineups:
+        return {
+            "ok": False,
+            "job_id": job_id,
+            "error": "Solver did not return any lineups.",
+            "warnings": warnings,
+            "stats": stats,
+        }
+
+    csv_headers = [
+        "lineup_index",
+        "lineup_salary",
+        "lineup_projection",
+        "lineup_projection_actual",
+        "slot",
+        "player_id",
+        "name",
+        "team",
+        "positions",
+        "salary",
+        "projection",
+        "used_projection",
+        "locked",
+    ]
+
+    with lineups_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csvmod.DictWriter(f, fieldnames=csv_headers)
+        writer.writeheader()
+        for lineup in lineups:
+            for player in lineup["players"]:
+                writer.writerow(
+                    {
+                        "lineup_index": lineup["index"],
+                        "lineup_salary": lineup["salary"],
+                        "lineup_projection": lineup["projection"],
+                        "lineup_projection_actual": lineup["projection_actual"],
+                        "slot": player["lineup_position"],
+                        "player_id": player["player_id"],
+                        "name": player["name"],
+                        "team": player["team"],
+                        "positions": "/".join(player["positions"]),
+                        "salary": player["salary"],
+                        "projection": player["projection"],
+                        "used_projection": player["used_projection"] if player["used_projection"] is not None else "",
+                        "locked": "true" if player["locked"] else "false",
+                    }
+                )
+
+    preview = lineups[:3]
+    response = {
+        "ok": True,
+        "job_id": job_id,
+        "requested": requested,
+        "generated": len(lineups),
+        "lineups": preview,
+        "lineups_csv": f"jobs/{job_id}/lineups.csv",
+        "warnings": warnings,
+        "stats": stats,
+        "solver": solver_key,
+        "site": site_key,
+        "sport": sport_key,
+        "locked_players": len(locked_data),
+    }
+    if len(lineups) > len(preview):
+        response["preview_count"] = len(preview)
+
+    return response

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,20 +5,161 @@
   <title>DFS Optimizer UI</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 24px; }
+    :root {
+      color-scheme: light;
+      --bg-color: #ffffff;
+      --text-color: #111111;
+      --muted-color: #555555;
+      --panel-bg: #f5f5f5;
+      --border-color: #d0d0d0;
+      --button-bg: #e9e9e9;
+      --button-text: #111111;
+      --table-header-bg: #f0f0f0;
+      --table-row-alt: #fafafa;
+      --link-color: #0b5fff;
+    }
+
+    body.dark-mode {
+      color-scheme: dark;
+      --bg-color: #0f1116;
+      --text-color: #f3f5f7;
+      --muted-color: #a0a8b8;
+      --panel-bg: #181c24;
+      --border-color: #2c3444;
+      --button-bg: #252c3a;
+      --button-text: #f3f5f7;
+      --table-header-bg: #1f2533;
+      --table-row-alt: #1a1f2a;
+      --link-color: #6ea8ff;
+    }
+
+    body {
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      margin: 24px;
+      background: var(--bg-color);
+      color: var(--text-color);
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    a { color: var(--link-color); }
+
     h1 { margin: 0 0 12px; }
-    fieldset { border: 1px solid #ddd; border-radius: 10px; padding: 12px; margin: 12px 0; }
+
+    fieldset {
+      border: 1px solid var(--border-color);
+      border-radius: 10px;
+      padding: 12px;
+      margin: 12px 0;
+      background: var(--panel-bg);
+    }
+
     legend { padding: 0 6px; }
+
     label { display:inline-block; margin:6px 12px 6px 0; }
-    input, select, button { padding:6px 8px; margin: 4px 8px; }
+
+    input, select, button {
+      padding:6px 8px;
+      margin: 4px 8px;
+      background: var(--bg-color);
+      color: var(--text-color);
+      border: 1px solid var(--border-color);
+      border-radius: 6px;
+    }
+
+    button {
+      background: var(--button-bg);
+      color: var(--button-text);
+      cursor: pointer;
+    }
+
+    button:hover {
+      filter: brightness(1.05);
+    }
+
     .row { display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
-    .muted { color:#666; }
-    pre { background:#f8f8f8; padding:10px; border-radius:8px; overflow:auto; }
+
+    .muted { color: var(--muted-color); }
+
+    pre {
+      background: var(--panel-bg);
+      padding:10px;
+      border-radius:8px;
+      overflow:auto;
+      border: 1px solid var(--border-color);
+    }
+
+    details summary { cursor:pointer; font-weight:600; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      color: inherit;
+    }
+
+    th, td {
+      border: 1px solid var(--border-color);
+      padding: 6px;
+      background: inherit;
+    }
+
+    th {
+      background: var(--table-header-bg);
+    }
+
+    tbody tr:nth-child(even) td {
+      background: var(--table-row-alt);
+    }
+
+    #poolTableWrap {
+      background: var(--panel-bg);
+      border: 1px solid var(--border-color);
+    }
+
+    .lineup-card {
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      padding: 10px;
+      margin: 10px 0;
+      background: var(--panel-bg);
+    }
+
+    .lineup-card h4 {
+      margin: 0 0 6px;
+    }
+
+    .lineup-meta {
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+
+    .lineup-card table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .lineup-card th,
+    .lineup-card td {
+      border: 1px solid var(--border-color);
+      padding: 6px;
+    }
+
+    .top-meta {
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 12px;
+    }
+
+    .top-meta p {
+      margin: 0;
+    }
   </style>
 </head>
 <body>
   <h1>DFS Optimizer (placeholder)</h1>
-  <p class="muted">Backend: FastAPI + pydfs + CBC (python-mip). Use this page to hit /health or send a CSV to /optimize.</p>
+  <div class="row top-meta">
+    <p class="muted">Backend: FastAPI + pydfs + CBC (python-mip). Use this page to hit /health or send a CSV to /optimize.</p>
+    <button id="themeToggle" type="button">Switch to dark mode</button>
+  </div>
 
   <fieldset>
     <legend>Health Check</legend>
@@ -26,214 +167,653 @@
     <pre id="outHealth"></pre>
   </fieldset>
 
-<fieldset>
-  <legend>Upload CSV & Header Mapping</legend>
-  <div class="row">
-    <label>CSV: <input type="file" id="csvFile" accept=".csv" /></label>
-    <label>Site:
-      <select id="site">
-        <option>FANDUEL</option><option>DRAFTKINGS</option>
-      </select>
-    </label>
-    <label>Sport:
-      <select id="sport">
-        <option>NFL</option><option>NBA</option><option>MLB</option><option>NHL</option>
-      </select>
-    </label>
-    <label>Solver:
-      <select id="solver"><option>mip</option><option>pulp</option></select>
-    </label>
-    <label>Pool size: <input type="number" id="poolSize" value="150" min="1" /></label>
-  </div>
-
-  <div class="row">
-    <button id="btnLoadHeaders">Load headers</button>
-    <button id="btnSaveTpl" disabled>Save mapping template</button>
-    <button id="btnLoadTpl" disabled>Load mapping template</button>
-  </div>
-
-  <div id="mappingForm" style="display:none; margin-top:8px;">
-    <h3>Map CSV columns</h3>
-    <div id="mappingGrid"></div>
+  <fieldset>
+    <legend>Upload CSV & Header Mapping</legend>
     <div class="row">
-      <button id="btnOptimize">Build mapping & Optimize</button>
+      <label>CSV: <input type="file" id="csvFile" accept=".csv" /></label>
+      <label>Site:
+        <select id="site">
+          <option>FANDUEL</option><option>DRAFTKINGS</option>
+        </select>
+      </label>
+      <label>Sport:
+        <select id="sport">
+          <option>NFL</option><option>NBA</option><option>MLB</option><option>NHL</option>
+        </select>
+      </label>
+      <label>Solver:
+        <select id="solver"><option>mip</option><option>pulp</option></select>
+      </label>
+      <label>Pool size: <input type="number" id="poolSize" value="150" min="1" /></label>
     </div>
-  </div>
 
-  <pre id="outOptimize"></pre>
-</fieldset>
+    <div class="row">
+      <button id="btnLoadHeaders">Load headers</button>
+      <button id="btnSaveTpl" disabled>Save mapping template</button>
+      <button id="btnLoadTpl" disabled>Load mapping template</button>
+    </div>
 
+    <div id="mappingForm" style="display:none; margin-top:8px;">
+      <h3>Map CSV columns</h3>
+      <div id="mappingGrid"></div>
+      <div class="row">
+        <button id="btnOptimize">Build mapping & Optimize</button>
+      </div>
+    </div>
+
+    <div id="optimizeOutput" style="margin:10px 0;">
+      <details id="optimizeDetails">
+        <summary>Optimize response (click to expand)</summary>
+        <pre id="outOptimize" style="max-height:240px;"></pre>
+      </details>
+    </div>
+    <div id="poolControls" style="display:none; margin:10px 0;">
+      <button id="btnLoadPool">Preview Player Pool</button>
+      <button id="btnSavePool" disabled>Save changes</button>
+      <span id="poolMeta" style="margin-left:10px;"></span>
+    </div>
+    <div id="poolTableWrap" style="max-height:400px; overflow:auto; display:none;"></div>
+  </fieldset>
+
+  <fieldset id="solvePanel" style="display:none;">
+    <legend>Solve Lineups</legend>
+    <div class="row">
+      <label>Lineups to generate: <input type="number" id="solveCount" value="20" min="1" max="150" /></label>
+      <button id="btnSolve">Solve lineups</button>
+      <span id="solveStatus" class="muted"></span>
+    </div>
+    <div id="solveWarnings" class="muted" style="margin:6px 0;"></div>
+    <div id="solveResults" style="display:none;">
+      <h3 style="margin-top:0;">Sample lineups</h3>
+      <div id="solveLineups"></div>
+    </div>
+  </fieldset>
 
   <script>
-    const API = "/api"; // adjust if reverse-proxy later
+    document.addEventListener("DOMContentLoaded", () => {
+      const API = "/api";
 
-    document.getElementById("btnHealth").onclick = async () => {
-      const r = await fetch(`${API}/health`);
-      document.getElementById("outHealth").textContent = JSON.stringify(await r.json(), null, 2);
-    };
+      const csvFile = document.getElementById("csvFile");
+      const site = document.getElementById("site");
+      const sport = document.getElementById("sport");
+      const solver = document.getElementById("solver");
+      const poolSize = document.getElementById("poolSize");
 
-    document.getElementById("btnSend").onclick = async () => {
-      const f = document.getElementById("csvFile").files[0];
-      if (!f) { alert("Pick a CSV"); return; }
-      const settings = {
-        site: document.getElementById("site").value,
-        sport: document.getElementById("sport").value,
-        solver: document.getElementById("solver").value,
-        pool_size: parseInt(document.getElementById("poolSize").value, 10) || 150,
-        params: {}
-      };
-      const fd = new FormData();
-      fd.append("settings", JSON.stringify(settings));
-      fd.append("csv", f);
-      const r = await fetch(`${API}/optimize`, { method: "POST", body: fd });
-      const json = await r.json().catch(() => ({ error: "non-JSON response" }));
-      document.getElementById("outOptimize").textContent = JSON.stringify(json, null, 2);
-    };
-  </script>
- <script>
-document.addEventListener("DOMContentLoaded", () => {
-  const API = "/api";
+      const btnHealth = document.getElementById("btnHealth");
+      const outHealth = document.getElementById("outHealth");
+      const btnLoadHeaders = document.getElementById("btnLoadHeaders");
+      const btnOptimize = document.getElementById("btnOptimize");
+      const btnSaveTpl = document.getElementById("btnSaveTpl");
+      const btnLoadTpl = document.getElementById("btnLoadTpl");
+      const themeToggle = document.getElementById("themeToggle");
 
-  // grab all elements explicitly
-  const csvFile     = document.getElementById("csvFile");
-  const site        = document.getElementById("site");
-  const sport       = document.getElementById("sport");
-  const solver      = document.getElementById("solver");
-  const poolSize    = document.getElementById("poolSize");
+      const mappingForm = document.getElementById("mappingForm");
+      const mappingGrid = document.getElementById("mappingGrid");
+      const outOptimize = document.getElementById("outOptimize");
+      const optimizeDetails = document.getElementById("optimizeDetails");
+      const poolControls = document.getElementById("poolControls");
+      const poolMeta = document.getElementById("poolMeta");
+      const poolTableWrap = document.getElementById("poolTableWrap");
+      const btnLoadPool = document.getElementById("btnLoadPool");
+      const btnSavePool = document.getElementById("btnSavePool");
+      const solvePanel = document.getElementById("solvePanel");
+      const solveCount = document.getElementById("solveCount");
+      const btnSolve = document.getElementById("btnSolve");
+      const solveStatus = document.getElementById("solveStatus");
+      const solveResults = document.getElementById("solveResults");
+      const solveLineups = document.getElementById("solveLineups");
+      const solveWarnings = document.getElementById("solveWarnings");
 
-  const btnLoadHeaders = document.getElementById("btnLoadHeaders");
-  const btnOptimize    = document.getElementById("btnOptimize");
-  const btnSaveTpl     = document.getElementById("btnSaveTpl");
-  const btnLoadTpl     = document.getElementById("btnLoadTpl");
+      const REQUIRED_KEYS = ["player_id","name","team","position","salary","projection"];
+      const OPTIONAL_KEYS = [
+        "max_exposure","min_exposure","projected_ownership",
+        "min_deviation","max_deviation","projection_floor","projection_ceil",
+        "confirmed_starter","progressive_scale"
+      ];
 
-  const mappingForm = document.getElementById("mappingForm");
-  const mappingGrid = document.getElementById("mappingGrid");
-  const outOptimize = document.getElementById("outOptimize");
+      const POOL_COLUMNS = [
+        "player_id","name","team","position","salary","projection",
+        "active","lock","exclude","max_exposure","min_exposure"
+      ];
+      const NUMERIC_POOL_COLUMNS = new Set(["salary","projection","max_exposure","min_exposure"]);
+      const BOOL_POOL_COLUMNS = new Set(["active","lock","exclude"]);
 
-  const REQUIRED_KEYS = ["player_id","name","team","position","salary","projection"];
-  const OPTIONAL_KEYS = [
-    "max_exposure","min_exposure","projected_ownership",
-    "min_deviation","max_deviation","projection_floor","projection_ceil",
-    "confirmed_starter","progressive_scale"
-  ];
+      let lastJobId = null;
+      let poolCache = [];
+      let poolView = [];
+      const poolDirty = new Map();
+      const poolIndex = new Map();
+      const sortState = { key: null, dir: "asc" };
 
-  function readSettings(){
-    return {
-      site: site.value,
-      sport: sport.value,
-      solver: solver.value,
-      pool_size: parseInt(poolSize.value,10) || 150,
-      params: {}
-    };
-  }
+      const escapeHtml = (value) => String(value ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      const escapeAttr = (value) => escapeHtml(value).replace(/"/g, "&quot;");
 
-  async function postForHeaders(file, settings){
-    const fd = new FormData();
-    fd.append("settings", JSON.stringify(settings));
-    fd.append("csv", file); // no mapping
-    const r = await fetch(`${API}/optimize`, { method:"POST", body:fd });
-    if(!r.ok) throw new Error(`Header load failed: ${r.status}`);
-    return r.json();
-  }
-
-  function guessHeader(key, headers){
-    const wants = {
-      player_id:["id","player id","fd_id","b_id"],
-      name:["name","nickname","player"],
-      team:["team","tm"],
-      position:["position","pos","roster position"],
-      salary:["salary","sal","cost"],
-      projection:["proj","projection","ppg_projection","fpts","points"]
-    }[key] || [key];
-    const lower = headers.map(h=>[h,h.toLowerCase()]);
-    for(const w of wants){
-      const hit = lower.find(([h,l])=>l.includes(w));
-      if(hit) return hit[0];
-    }
-    return "";
-  }
-
-  function renderMappingForm(headers){
-    mappingGrid.innerHTML = "";
-    const makeRow = (label,key,required)=>{
-      const wrap = document.createElement("div"); wrap.style.margin="6px 0";
-      const lab = document.createElement("label"); lab.textContent = `${label}${required?" *":""}: `;
-      const sel = document.createElement("select"); sel.dataset.key = key;
-
-      const empty = document.createElement("option");
-      empty.value = ""; empty.textContent = required ? "-- choose --" : "(not present)";
-      sel.appendChild(empty);
-
-      headers.forEach(h=>{
-        const o=document.createElement("option"); o.value=h; o.textContent=h; sel.appendChild(o);
+      btnHealth?.addEventListener("click", async () => {
+        try {
+          const resp = await fetch(`${API}/health`);
+          const json = await resp.json();
+          outHealth.textContent = JSON.stringify(json, null, 2);
+        } catch (err) {
+          outHealth.textContent = JSON.stringify({ error: err?.message || String(err) }, null, 2);
+        }
       });
 
-      if(required){
-        const g=guessHeader(key, headers);
-        if(g) sel.value=g;
+      function resetPoolUI() {
+        poolDirty.clear();
+        btnSavePool.disabled = true;
+        sortState.key = null;
+        sortState.dir = "asc";
+        poolView = [];
+        poolIndex.clear();
       }
 
-      wrap.appendChild(lab);
-      wrap.appendChild(sel);
-      mappingGrid.appendChild(wrap);
-    };
-    REQUIRED_KEYS.forEach(k=>makeRow(k,k,true));
-    OPTIONAL_KEYS.forEach(k=>makeRow(k,k,false));
-  }
-
-  btnLoadHeaders.onclick = async ()=>{
-    const f = csvFile.files[0]; if(!f){ alert("Pick a CSV first"); return; }
-    try{
-      const js = await postForHeaders(f, readSettings());
-      const headers = js?.csv_summary?.headers || [];
-      if(!headers.length){ alert("No headers detected."); return; }
-      renderMappingForm(headers);
-      mappingForm.style.display = "block";
-      btnSaveTpl.disabled = false;
-      btnLoadTpl.disabled = false;
-      outOptimize.textContent = JSON.stringify(js.csv_summary, null, 2);
-    }catch(e){ alert(e.message); }
-  };
-
-  btnOptimize.onclick = async ()=>{
-    const f = csvFile.files[0]; if(!f){ alert("Pick a CSV first"); return; }
-    const selects = mappingGrid.querySelectorAll("select");
-    const mapping = {};
-    for(const sel of selects){
-      const key = sel.dataset.key;
-      if(REQUIRED_KEYS.includes(key) && !sel.value){
-        alert(`Select a column for ${key}`); return;
+      function resetSolveUI() {
+        if (solveStatus) solveStatus.textContent = "";
+        if (solveWarnings) solveWarnings.textContent = "";
+        if (solveLineups) solveLineups.innerHTML = "";
+        if (solveResults) solveResults.style.display = "none";
       }
-      if(sel.value) mapping[key] = sel.value;
-    }
-    const fd = new FormData();
-    fd.append("settings", JSON.stringify(readSettings()));
-    fd.append("csv", f);
-    fd.append("mapping", JSON.stringify(mapping));
-    const r = await fetch(`${API}/optimize`, { method:"POST", body:fd });
-    const js = await r.json().catch(()=>({error:"non-JSON"}));
-    outOptimize.textContent = JSON.stringify(js, null, 2);
-  };
 
-  // localStorage templates
-  const tplKey = ()=> `optimizer_mapping_${site.value}_${sport.value}`;
+      function onOptimizeResponse(json) {
+        outOptimize.textContent = JSON.stringify(json, null, 2);
+        lastJobId = json?.job?.job_id || null;
+        poolControls.style.display = lastJobId ? "block" : "none";
+        poolMeta.textContent = "";
+        poolTableWrap.style.display = "none";
+        poolTableWrap.innerHTML = "";
+        resetPoolUI();
+        resetSolveUI();
+        if (solvePanel) {
+          solvePanel.style.display = lastJobId ? "block" : "none";
+        }
+        poolCache = [];
+        if (optimizeDetails) {
+          optimizeDetails.open = false;
+        }
+      }
 
-  btnSaveTpl.onclick = ()=>{
-    const selects = mappingGrid.querySelectorAll("select");
-    const mapping = {};
-    for(const sel of selects){ if(sel.value) mapping[sel.dataset.key]=sel.value; }
-    localStorage.setItem(tplKey(), JSON.stringify(mapping));
-    alert("Template saved.");
-  };
+      function printOptimize(json) {
+        onOptimizeResponse(json);
+      }
 
-  btnLoadTpl.onclick = ()=>{
-    const raw = localStorage.getItem(tplKey());
-    if(!raw){ alert("No template for this Site/Sport."); return; }
-    const mapping = JSON.parse(raw);
-    mappingGrid.querySelectorAll("select").forEach(sel=>{
-      if(mapping[sel.dataset.key]) sel.value = mapping[sel.dataset.key];
+      async function loadPool() {
+        if (!lastJobId) {
+          alert("No job_id. Run Optimize first.");
+          return;
+        }
+        const resp = await fetch(`${API}/jobs/${lastJobId}/pool`);
+        if (!resp.ok) {
+          alert(`Failed to load pool: ${resp.status}`);
+          return;
+        }
+        const js = await resp.json();
+        poolCache = js.players || [];
+        if (js.error) {
+          alert(js.error);
+        }
+        const total = typeof js.count === "number" ? js.count : poolCache.length;
+        const shown = Math.min(poolCache.length, 200);
+        poolMeta.textContent = shown < total ? `rows: ${total} (showing ${shown})` : `rows: ${total}`;
+        resetPoolUI();
+        for (const row of poolCache) {
+          if (!row) continue;
+          const pid = row.player_id;
+          if (pid === undefined || pid === null) continue;
+          poolIndex.set(String(pid), row);
+        }
+        poolView = poolCache.slice();
+        renderPoolTable(poolView.slice(0, 200));
+      }
+
+      function markDirty(pid, key, dirtyValue, rowValue) {
+        if (!pid || !key) {
+          return;
+        }
+        const pidKey = String(pid);
+        const rowObj = poolIndex.get(pidKey);
+        const playerIdValue = rowObj && rowObj.player_id !== undefined ? rowObj.player_id : pid;
+        const existing = poolDirty.get(pidKey) || { player_id: playerIdValue };
+        existing[key] = dirtyValue;
+        poolDirty.set(pidKey, existing);
+        if (rowObj) {
+          rowObj[key] = rowValue;
+        }
+        btnSavePool.disabled = false;
+      }
+
+      function renderPoolTable(rows) {
+        poolTableWrap.style.display = "block";
+        if (!rows.length) {
+          poolTableWrap.innerHTML = "<i>No rows.</i>";
+          return;
+        }
+
+        const thead = `<thead><tr>${POOL_COLUMNS.map((col) => {
+          const label = `${escapeHtml(col)}${sortState.key === col ? (sortState.dir === "asc" ? " ▲" : " ▼") : ""}`;
+          return `<th data-key="${escapeAttr(col)}" style="position:sticky;top:0;">${label}</th>`;
+        }).join("")}</tr></thead>`;
+
+        const body = rows.map((row) => {
+          const pid = row.player_id;
+          const pidAttr = escapeAttr(pid);
+          const cells = POOL_COLUMNS.map((col) => {
+            const rawVal = row[col] ?? "";
+            if (["projection","max_exposure","min_exposure"].includes(col)) {
+              return `<td><input type="text" data-pid="${pidAttr}" data-key="${col}" value="${escapeAttr(rawVal)}" style="width:6em"/></td>`;
+            }
+            if (["active","lock","exclude"].includes(col)) {
+              const checked = String(rawVal).toLowerCase() === "true" ? "checked" : "";
+              return `<td style="text-align:center"><input type="checkbox" data-pid="${pidAttr}" data-key="${col}" ${checked}/></td>`;
+            }
+            return `<td>${escapeHtml(rawVal)}</td>`;
+          });
+          return `<tr>${cells.join("")}</tr>`;
+        }).join("");
+
+        poolTableWrap.innerHTML = `<table style="border-collapse:collapse;width:100%">${thead}<tbody>${body}</tbody></table>`;
+
+        poolTableWrap.querySelectorAll("th[data-key]").forEach((th) => {
+          th.style.cursor = "pointer";
+          th.addEventListener("click", () => {
+            const key = th.dataset.key;
+            if (key) {
+              applySort(key);
+            }
+          });
+        });
+
+        poolTableWrap.querySelectorAll('input[type="text"]').forEach((input) => {
+          input.addEventListener("change", (event) => {
+            const pid = event.target.dataset.pid;
+            const key = event.target.dataset.key;
+            const value = event.target.value;
+            markDirty(pid, key, value, value);
+          });
+        });
+
+        poolTableWrap.querySelectorAll('input[type="checkbox"]').forEach((box) => {
+          box.addEventListener("change", (event) => {
+            const pid = event.target.dataset.pid;
+            const key = event.target.dataset.key;
+            const value = event.target.checked;
+            markDirty(pid, key, value, value ? "true" : "false");
+          });
+        });
+      }
+
+      function parseNumeric(value) {
+        if (value === undefined || value === null) {
+          return null;
+        }
+        const str = String(value).trim();
+        if (!str) {
+          return null;
+        }
+        const num = Number(str.replace(/,/g, ""));
+        return Number.isFinite(num) ? num : null;
+      }
+
+      function compareRows(a, b, key) {
+        if (NUMERIC_POOL_COLUMNS.has(key)) {
+          const av = parseNumeric(a[key]);
+          const bv = parseNumeric(b[key]);
+          if (av === null && bv === null) return 0;
+          if (av === null) return 1;
+          if (bv === null) return -1;
+          return av - bv;
+        }
+        if (BOOL_POOL_COLUMNS.has(key)) {
+          const av = String(a[key]).toLowerCase() === "true" ? 1 : 0;
+          const bv = String(b[key]).toLowerCase() === "true" ? 1 : 0;
+          return av - bv;
+        }
+        const av = String(a[key] ?? "").toLowerCase();
+        const bv = String(b[key] ?? "").toLowerCase();
+        if (av < bv) return -1;
+        if (av > bv) return 1;
+        return 0;
+      }
+
+      function applySort(key) {
+        if (!key) {
+          return;
+        }
+        if (sortState.key === key) {
+          sortState.dir = sortState.dir === "asc" ? "desc" : "asc";
+        } else {
+          sortState.key = key;
+          sortState.dir = "asc";
+        }
+
+        poolView = poolCache.slice();
+        if (sortState.key) {
+          poolView.sort((a, b) => {
+            const cmp = compareRows(a, b, sortState.key);
+            return sortState.dir === "asc" ? cmp : -cmp;
+          });
+        }
+
+        renderPoolTable(poolView.slice(0, 200));
+      }
+
+      btnLoadPool?.addEventListener("click", loadPool);
+
+      btnSavePool?.addEventListener("click", async () => {
+        if (!lastJobId) {
+          return;
+        }
+        const updates = Array.from(poolDirty.values());
+        if (!updates.length) {
+          return;
+        }
+        try {
+          const resp = await fetch(`${API}/jobs/${lastJobId}/pool`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ players: updates })
+          });
+          if (!resp.ok) {
+            alert(`Save failed: ${resp.status}`);
+            return;
+          }
+          const js = await resp.json();
+          if (!js.ok) {
+            alert(js.error || "Save failed");
+            return;
+          }
+          await loadPool();
+          alert(`Saved ${js.changed} rows.`);
+        } catch (err) {
+          alert(err?.message || "Save failed");
+        }
+      });
+
+      function renderLineupPreview(lineups) {
+        if (!solveLineups) {
+          return;
+        }
+        if (!Array.isArray(lineups) || !lineups.length) {
+          solveLineups.innerHTML = "<i>No sample lineups.</i>";
+          if (solveResults) solveResults.style.display = "block";
+          return;
+        }
+
+        const html = lineups.map((lineup) => {
+          const meta = `Lineup ${escapeHtml(lineup.index)} · Salary ${escapeHtml(lineup.salary)} · Projection ${escapeHtml(lineup.projection)}`;
+          const rows = (lineup.players || []).map((player) => {
+            const positions = Array.isArray(player.positions) ? player.positions.join("/") : player.positions;
+            return `<tr>` +
+              `<td>${escapeHtml(player.lineup_position)}</td>` +
+              `<td>${escapeHtml(player.name)}</td>` +
+              `<td>${escapeHtml(positions)}</td>` +
+              `<td>${escapeHtml(player.team)}</td>` +
+              `<td style="text-align:right">${escapeHtml(player.salary)}</td>` +
+              `<td style="text-align:right">${escapeHtml(player.projection)}</td>` +
+              `<td>${player.locked ? "✅" : ""}</td>` +
+            `</tr>`;
+          }).join("");
+          const table = `<table><thead><tr>` +
+            `<th>Slot</th><th>Name</th><th>Pos</th><th>Team</th><th>Salary</th><th>Proj</th><th>Lock</th>` +
+            `</tr></thead><tbody>${rows}</tbody></table>`;
+          return `<div class="lineup-card"><div class="lineup-meta">${meta}</div>${table}</div>`;
+        }).join("");
+
+        solveLineups.innerHTML = html;
+        if (solveResults) solveResults.style.display = "block";
+      }
+
+      btnSolve?.addEventListener("click", async () => {
+        if (!lastJobId) {
+          alert("No job available. Run Optimize first.");
+          return;
+        }
+        const requested = parseInt(solveCount?.value ?? "20", 10) || 20;
+        const payload = {
+          job_id: lastJobId,
+          num_lineups: requested,
+          site: site.value,
+          sport: sport.value,
+          solver: solver.value
+        };
+
+        if (solveStatus) solveStatus.textContent = "Solving...";
+        if (solveWarnings) solveWarnings.textContent = "";
+        if (solveLineups) solveLineups.innerHTML = "";
+        if (solveResults) solveResults.style.display = "none";
+        btnSolve.disabled = true;
+        try {
+          const resp = await fetch(`${API}/solve`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload)
+          });
+          const js = await resp.json().catch(() => ({ ok: false, error: "Invalid JSON response" }));
+          if (!resp.ok || !js.ok) {
+            const message = js?.error || `Solve failed (${resp.status})`;
+            resetSolveUI();
+            if (solveStatus) solveStatus.textContent = message;
+            if (message) alert(message);
+            return;
+          }
+          const summaryBits = [];
+          summaryBits.push(`Generated ${js.generated} lineups`);
+          if (js.requested && js.requested !== js.generated) {
+            summaryBits.push(`requested ${js.requested}`);
+          }
+          if (js.lineups_csv) {
+            summaryBits.push(`saved to ${js.lineups_csv}`);
+          }
+          if (js.stats) {
+            const eligible = js.stats.eligible ?? 0;
+            const total = js.stats.total_rows ?? 0;
+            summaryBits.push(`eligible players ${eligible}/${total}`);
+          }
+          if (solveStatus) solveStatus.textContent = summaryBits.join(" • ");
+          if (Array.isArray(js.warnings) && js.warnings.length && solveWarnings) {
+            solveWarnings.textContent = `Warnings: ${js.warnings.join("; ")}`;
+          }
+          renderLineupPreview(js.lineups || []);
+        } catch (err) {
+          const message = err?.message || "Solve failed";
+          if (solveStatus) solveStatus.textContent = message;
+          alert(message);
+        } finally {
+          btnSolve.disabled = false;
+        }
+      });
+
+      function readSettings() {
+        return {
+          site: site.value,
+          sport: sport.value,
+          solver: solver.value,
+          pool_size: parseInt(poolSize.value, 10) || 150,
+          params: {}
+        };
+      }
+
+      async function postForHeaders(file, settings) {
+        const fd = new FormData();
+        fd.append("settings", JSON.stringify(settings));
+        fd.append("csv", file);
+        const resp = await fetch(`${API}/optimize`, { method: "POST", body: fd });
+        if (!resp.ok) throw new Error(`Header load failed: ${resp.status}`);
+        return resp.json();
+      }
+
+      function guessHeader(key, headers) {
+        const wants = {
+          player_id: ["id","player id","fd_id","b_id"],
+          name: ["name","nickname","player"],
+          team: ["team","tm"],
+          position: ["position","pos","roster position"],
+          salary: ["salary","sal","cost"],
+          projection: ["proj","projection","ppg_projection","fpts","points"]
+        }[key] || [key];
+        const lower = headers.map((h) => [h, h.toLowerCase()]);
+        for (const w of wants) {
+          const hit = lower.find(([h, l]) => l.includes(w));
+          if (hit) return hit[0];
+        }
+        return "";
+      }
+
+      function renderMappingForm(headers) {
+        mappingGrid.innerHTML = "";
+        const makeRow = (label, key, required) => {
+          const wrap = document.createElement("div");
+          wrap.style.margin = "6px 0";
+          const lab = document.createElement("label");
+          lab.textContent = `${label}${required ? " *" : ""}: `;
+          const sel = document.createElement("select");
+          sel.dataset.key = key;
+
+          const empty = document.createElement("option");
+          empty.value = "";
+          empty.textContent = required ? "-- choose --" : "(not present)";
+          sel.appendChild(empty);
+
+          headers.forEach((h) => {
+            const opt = document.createElement("option");
+            opt.value = h;
+            opt.textContent = h;
+            sel.appendChild(opt);
+          });
+
+          if (required) {
+            const guessed = guessHeader(key, headers);
+            if (guessed) sel.value = guessed;
+          }
+
+          wrap.appendChild(lab);
+          wrap.appendChild(sel);
+          mappingGrid.appendChild(wrap);
+        };
+        REQUIRED_KEYS.forEach((key) => makeRow(key, key, true));
+        OPTIONAL_KEYS.forEach((key) => makeRow(key, key, false));
+      }
+
+      btnLoadHeaders?.addEventListener("click", async () => {
+        const file = csvFile.files[0];
+        if (!file) {
+          alert("Pick a CSV first");
+          return;
+        }
+        try {
+          const js = await postForHeaders(file, readSettings());
+          const headers = js?.csv_summary?.headers || [];
+          if (!headers.length) {
+            alert("No headers detected.");
+            return;
+          }
+          renderMappingForm(headers);
+          mappingForm.style.display = "block";
+          btnSaveTpl.disabled = false;
+          btnLoadTpl.disabled = false;
+          outOptimize.textContent = JSON.stringify(js.csv_summary, null, 2);
+          if (optimizeDetails) {
+            optimizeDetails.open = false;
+          }
+        } catch (err) {
+          alert(err?.message || "Header load failed");
+        }
+      });
+
+      btnOptimize?.addEventListener("click", async () => {
+        const file = csvFile.files[0];
+        if (!file) {
+          alert("Pick a CSV first");
+          return;
+        }
+        const selects = mappingGrid.querySelectorAll("select");
+        const mapping = {};
+        for (const sel of selects) {
+          const key = sel.dataset.key;
+          if (REQUIRED_KEYS.includes(key) && !sel.value) {
+            alert(`Select a column for ${key}`);
+            return;
+          }
+          if (sel.value) {
+            mapping[key] = sel.value;
+          }
+        }
+        const fd = new FormData();
+        fd.append("settings", JSON.stringify(readSettings()));
+        fd.append("csv", file);
+        fd.append("mapping", JSON.stringify(mapping));
+        const resp = await fetch(`${API}/optimize`, { method: "POST", body: fd });
+        const json = await resp.json().catch(() => ({ error: "non-JSON" }));
+        printOptimize(json);
+      });
+
+      const tplKey = () => `optimizer_mapping_${site.value}_${sport.value}`;
+
+      btnSaveTpl?.addEventListener("click", () => {
+        const selects = mappingGrid.querySelectorAll("select");
+        const mapping = {};
+        for (const sel of selects) {
+          if (sel.value) {
+            mapping[sel.dataset.key] = sel.value;
+          }
+        }
+        localStorage.setItem(tplKey(), JSON.stringify(mapping));
+        alert("Template saved.");
+      });
+
+      btnLoadTpl?.addEventListener("click", () => {
+        const raw = localStorage.getItem(tplKey());
+        if (!raw) {
+          alert("No template for this Site/Sport.");
+          return;
+        }
+        const mapping = JSON.parse(raw);
+        mappingGrid.querySelectorAll("select").forEach((sel) => {
+          if (mapping[sel.dataset.key]) {
+            sel.value = mapping[sel.dataset.key];
+          }
+        });
+        alert("Template loaded.");
+      });
+
+      const THEME_STORAGE_KEY = "dfs_optimizer_theme";
+      let currentTheme = "light";
+
+      function applyTheme(theme) {
+        const normalized = theme === "dark" ? "dark" : "light";
+        currentTheme = normalized;
+        document.body.classList.toggle("dark-mode", normalized === "dark");
+        if (themeToggle) {
+          themeToggle.textContent = normalized === "dark" ? "Switch to light mode" : "Switch to dark mode";
+          themeToggle.setAttribute("aria-pressed", normalized === "dark" ? "true" : "false");
+        }
+        try {
+          localStorage.setItem(THEME_STORAGE_KEY, normalized);
+        } catch (err) {
+          console.warn("Theme preference not persisted", err);
+        }
+      }
+
+      function initTheme() {
+        let stored = null;
+        try {
+          stored = localStorage.getItem(THEME_STORAGE_KEY);
+        } catch (err) {
+          stored = null;
+        }
+        if (stored === "dark" || stored === "light") {
+          currentTheme = stored;
+        } else if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+          currentTheme = "dark";
+        }
+        applyTheme(currentTheme);
+      }
+
+      initTheme();
+
+      themeToggle?.addEventListener("click", () => {
+        applyTheme(currentTheme === "dark" ? "light" : "dark");
+      });
     });
-    alert("Template loaded.");
-  };
-});
-</script>
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add helper utilities and a POST `/solve` endpoint that prepares the edited pool, calls the optimizer, and writes lineups back to the job directory
- return solver statistics, warnings, and a preview of generated lineups for the client
- expose a solve panel in the frontend with themed styling, a sample lineup preview, and status messaging that calls the new API

## Testing
- python -m compileall backend/app/main.py frontend/index.html

------
https://chatgpt.com/codex/tasks/task_b_68e56ed2396c8328a1f11861f9855f9c